### PR TITLE
Add support for GlusterFS FUSE client mounts

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,7 @@ Package: openmediavault-remotemount
 Architecture: all
 Depends: cifs-utils,
          curlftpfs,
+         glusterfs-client,
          omvextras-netrc,
          openmediavault (>= 3.0.74),
          php5-cli,

--- a/usr/share/openmediavault/datamodels/conf.service.remotemount.json
+++ b/usr/share/openmediavault/datamodels/conf.service.remotemount.json
@@ -26,7 +26,7 @@
 		"mounttype": {
 			"description": "The type of remote mount",
 			"type": "string",
-			"enum": ["cifs","ftpfs","nfs"]
+			"enum": ["cifs","ftpfs","nfs","fuse.glusterfs"]
 		},
 		"server": {
 			"description": "Server FQDN or IP address",

--- a/usr/share/openmediavault/datamodels/rpc.remotemount.json
+++ b/usr/share/openmediavault/datamodels/rpc.remotemount.json
@@ -20,7 +20,7 @@
 			},
 			"mounttype": {
 				"type": "string",
-				"enum": ["cifs","ftpfs","nfs"]
+				"enum": ["cifs","ftpfs","nfs","fuse.glusterfs"]
 			},
 			"server": {
 				"type": "string",

--- a/usr/share/openmediavault/mkconf/fstab.d/15remotemount
+++ b/usr/share/openmediavault/mkconf/fstab.d/15remotemount
@@ -72,6 +72,17 @@ foreach ($objects['data'] as $object) {
                 $object['options']
             );
             break;
+
+        case 'fuse.glusterfs':
+            echo sprintf(
+                "%s:/%s %s glusterfs %s 0 0\n",
+                $object['server'],
+                $object['sharename'],
+                $mountPoint,
+                $object['options']
+            );
+            break;
+
     }
 }
 

--- a/usr/share/php/openmediavault/system/filesystem/backend/glusterfs.inc
+++ b/usr/share/php/openmediavault/system/filesystem/backend/glusterfs.inc
@@ -16,17 +16,17 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+namespace OMV\System\Filesystem\Backend;
 
 use OMV\Config\Database;
-use OMV\System\Filesystem\Backend\Manager;
-use OMV\System\Filesystem\Backend\Cifs;
-use OMV\System\Filesystem\Backend\Ftpfs;
-use OMV\System\Filesystem\Backend\Nfs;
-use OMV\System\Filesystem\Backend\Glusterfs;
 
-$database = Database::getInstance();
-$filesystemBackendManager = Manager::getInstance();
-$filesystemBackendManager->registerBackend(new Cifs($database));
-$filesystemBackendManager->registerBackend(new Ftpfs($database));
-$filesystemBackendManager->registerBackend(new Nfs($database));
-$filesystemBackendManager->registerBackend(new Glusterfs($database));
+class Glusterfs extends RemoteAbstract
+{
+    public function __construct(Database $database)
+    {
+        parent::__construct($database);
+
+        $this->type = 'fuse.glusterfs';
+        $this->properties = self::PROP_POSIX_ACL;
+    }
+}

--- a/usr/share/php/openmediavault/system/filesystem/backend/remoteabstract.inc
+++ b/usr/share/php/openmediavault/system/filesystem/backend/remoteabstract.inc
@@ -185,6 +185,11 @@ abstract class RemoteAbstract extends BackendAbstract
 
         foreach (new SplFileObject($mountsFile) as $content) {
             $splitContent = preg_split('/\s+/', $content);
+
+	    if ($splitContent[2] == 'glusterfs') {
+		$splitContent[2] = 'fuse.glusterfs';
+	    }
+
             if ($type === $splitContent[2]) {
                 if ($fsname === $splitContent[0] || $fsname === $splitContent[1]) {
                     return $splitContent[1];

--- a/usr/share/php/openmediavault/system/filesystem/remote.inc
+++ b/usr/share/php/openmediavault/system/filesystem/remote.inc
@@ -416,7 +416,6 @@ class Remote implements IFilesystem, ISharedFolderCandidate
     public function mount($options = '')
     {
         $cmdArgs = [];
-        $cmdArgs[] = "-v";
         if (!empty($options)) {
             if (!is_array($options))
                 $options = [ $options ];

--- a/var/www/openmediavault/js/omv/module/admin/storage/remotemount/Mount.js
+++ b/var/www/openmediavault/js/omv/module/admin/storage/remotemount/Mount.js
@@ -52,6 +52,13 @@ Ext.define('OMV.module.admin.storage.remotemount.Mount', {
             }],
             name: ['sharename'],
             properties: ['!show', '!submitValue', 'allowBlank']
+	},{
+            conditions: [{
+                name: 'mounttype',
+                value: 'fuse.glusterfs'
+            }],
+            name: ['nfs4', 'username', 'password'],
+            properties: ['!show', '!submitValue']
         }]
     }],
 
@@ -69,6 +76,7 @@ Ext.define('OMV.module.admin.storage.remotemount.Mount', {
             queryMode: 'local',
             store: [
 //                [ 'ftpfs', _('FTPFS') ],
+		[ 'fuse.glusterfs', _('GLUSTERFS') ],
                 [ 'nfs', _('NFS') ],
                 [ 'cifs', _('SMB/CIFS') ]
             ],
@@ -101,7 +109,9 @@ Ext.define('OMV.module.admin.storage.remotemount.Mount', {
             allowBlank: false,
             plugins: [{
                 ptype: 'fieldinfo',
-                text: _('Use FQDN, hostname, or IP address.')
+                text: _('Use FQDN, hostname, or IP address.') +
+			'<br />' +
+		      _('For GLUSTERFS, use any node server name or IP address.')
             }]
         },{
             xtype: 'textfield',
@@ -113,7 +123,9 @@ Ext.define('OMV.module.admin.storage.remotemount.Mount', {
                 ptype: 'fieldinfo',
                 text: _('For SMB/CIFS, use the share name only.') +
                         '<br />' +
-                      _('For NFS, use the export path (ie /export/nfs_share_name).')
+                      _('For NFS, use the export path (ie /export/nfs_share_name).') +
+			'<br />' +
+		      _('For GLUSTERFS, use volume name only.')
             }]
         },{
             xtype: 'checkbox',
@@ -152,7 +164,11 @@ Ext.define('OMV.module.admin.storage.remotemount.Mount', {
                         '<a href="https://linux.die.net/man/1/curlftpfs" target="_blank">curlftpfs</a>' +
                         '<br />' +
                       _('For NFS options, see man page for ') +
-                        '<a href="https://linux.die.net/man/8/mount.nfs" target="_blank">mount.nfs</a>'
+                        '<a href="https://linux.die.net/man/8/mount.nfs" target="_blank">mount.nfs</a>' +
+			'<br />' +
+		      _('For GLUSTERFS options, see man page for ') +
+			'<a href="https://linux.die.net/man/8/mount.glusterfs" target="_blank">mount.glusterfs</a>'
+
             }]
         }];
     },
@@ -171,5 +187,10 @@ Ext.define('OMV.module.admin.storage.remotemount.Mount', {
         if (newValue === 'nfs') {
             options.setValue('rsize=8192,wsize=8192,timeo=14,intr,nofail');
         }
+
+	if (newValue === 'fuse.glusterfs') {
+	    options.setValue('_netdev,acl');
+	}
+
     }
 });

--- a/var/www/openmediavault/js/omv/module/admin/storage/remotemount/Mounts.js
+++ b/var/www/openmediavault/js/omv/module/admin/storage/remotemount/Mounts.js
@@ -57,6 +57,9 @@ Ext.define('OMV.module.admin.storage.remotemount.Mounts', {
                 case 'nfs':
                     content = _("NFS");
                     break;
+		case 'fuse.glusterfs':
+		    content = _("GLUSTERFS");
+		    break;
             }
             return content;
         }


### PR DESCRIPTION
I've added support for mounting glusterfs volumes through FUSE client. To do so I've needed to do some conversions between mount type 'glusterfs' and 'fuse.glusterfs' because each place needs a different name.

I've also had troubles with the '-v' mount option, which is not supported in gluster. It seems that this option doesn't have any effect for any other remote mount, so I've decided to remove it.