### PR TITLE
add 9pfs support

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+openmediavault-remotemount (4.0.6) stable; urgency=low
+
+  * add 9pfs support
+
+ -- OpenMediaVault Plugin Developers <plugins@omv-extras.org>  Fri, 12 Apr 2019 01:08:04 +0900
+
 openmediavault-remotemount (4.0.5) stable; urgency=low
 
   * Fix filesystem tab error

--- a/usr/share/openmediavault/datamodels/conf.service.remotemount.json
+++ b/usr/share/openmediavault/datamodels/conf.service.remotemount.json
@@ -26,7 +26,7 @@
 		"mounttype": {
 			"description": "The type of remote mount",
 			"type": "string",
-			"enum": ["cifs","ftpfs","nfs","fuse.glusterfs"]
+			"enum": ["cifs","ftpfs","nfs","fuse.glusterfs", "9p"]
 		},
 		"server": {
 			"description": "Server FQDN or IP address",

--- a/usr/share/openmediavault/datamodels/rpc.remotemount.json
+++ b/usr/share/openmediavault/datamodels/rpc.remotemount.json
@@ -20,11 +20,11 @@
 			},
 			"mounttype": {
 				"type": "string",
-				"enum": ["cifs","ftpfs","nfs","fuse.glusterfs"]
+				"enum": ["cifs","ftpfs","nfs","fuse.glusterfs","9p"],
+				"required": true
 			},
 			"server": {
-				"type": "string",
-				"required": true
+				"type": "string"
 			},
 			"sharename": {
 				"type": "string"

--- a/usr/share/openmediavault/engined/inc/59remotemount.inc
+++ b/usr/share/openmediavault/engined/inc/59remotemount.inc
@@ -24,6 +24,7 @@ use OMV\System\Filesystem\Backend\Ftpfs;
 use OMV\System\Filesystem\Backend\Nfs;
 use OMV\System\Filesystem\Backend\Nfs4;
 use OMV\System\Filesystem\Backend\Glusterfs;
+use OMV\System\Filesystem\Backend\Plan9;
 
 $database = Database::getInstance();
 $filesystemBackendManager = Manager::getInstance();
@@ -32,3 +33,4 @@ $filesystemBackendManager->registerBackend(new Ftpfs($database));
 $filesystemBackendManager->registerBackend(new Nfs($database));
 $filesystemBackendManager->registerBackend(new Nfs4($database));
 $filesystemBackendManager->registerBackend(new Glusterfs($database));
+$filesystemBackendManager->registerBackend(new Plan9($database));

--- a/usr/share/openmediavault/mkconf/fstab.d/15remotemount
+++ b/usr/share/openmediavault/mkconf/fstab.d/15remotemount
@@ -83,6 +83,14 @@ foreach ($objects['data'] as $object) {
             );
             break;
 
+        case '9p':
+           echo sprintf(
+               "%s %s 9p %s 0 0\n",
+               $object['sharename'],
+               $mountPoint,
+               $object['options']
+           );
+           break;
     }
 }
 

--- a/usr/share/php/openmediavault/system/filesystem/backend/plan9.inc
+++ b/usr/share/php/openmediavault/system/filesystem/backend/plan9.inc
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Copyright (C) 2014-2018 OpenMediaVault Plugin Developers.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace OMV\System\Filesystem\Backend;
+
+use OMV\Config\Database;
+
+class Plan9 extends RemoteAbstract
+{
+    public function __construct(Database $database)
+    {
+        parent::__construct($database);
+
+        $this->type = '9p';
+        $this->properties = self::PROP_POSIX_ACL;
+    }
+}

--- a/var/www/openmediavault/js/omv/module/admin/storage/remotemount/Mount.js
+++ b/var/www/openmediavault/js/omv/module/admin/storage/remotemount/Mount.js
@@ -59,6 +59,13 @@ Ext.define('OMV.module.admin.storage.remotemount.Mount', {
             }],
             name: ['nfs4', 'username', 'password'],
             properties: ['!show', '!submitValue']
+        },{
+            conditions: [{
+                name: 'mounttype',
+                value: '9p'
+            }],
+            name: ['nfs4', 'username', 'password', 'server'],
+            properties: ['!show', '!submitValue', 'allowBlank']
         }]
     }],
 
@@ -78,7 +85,8 @@ Ext.define('OMV.module.admin.storage.remotemount.Mount', {
 //                [ 'ftpfs', _('FTPFS') ],
                 [ 'fuse.glusterfs', _('GLUSTERFS') ],
                 [ 'nfs', _('NFS') ],
-                [ 'cifs', _('SMB/CIFS') ]
+                [ 'cifs', _('SMB/CIFS') ],
+                [ '9p', _('9PFS') ]
             ],
             editable: false,
             triggerAction: 'all',
@@ -125,7 +133,9 @@ Ext.define('OMV.module.admin.storage.remotemount.Mount', {
                         '<br />' +
                       _('For NFS, use the export path (ie /export/nfs_share_name).') +
                         '<br />' +
-                      _('For GLUSTERFS, use volume name only.')
+                      _('For GLUSTERFS, use volume name only.') +
+                        '<br />' +
+                      _('For 9PFS, use mount tag')
             }]
         },{
             xtype: 'checkbox',
@@ -167,8 +177,11 @@ Ext.define('OMV.module.admin.storage.remotemount.Mount', {
                         '<a href="https://linux.die.net/man/8/mount.nfs" target="_blank">mount.nfs</a>' +
                         '<br />' +
                       _('For GLUSTERFS options, see man page for ') +
-                        '<a href="https://linux.die.net/man/8/mount.glusterfs" target="_blank">mount.glusterfs</a>'
-            }]
+                        '<a href="https://linux.die.net/man/8/mount.glusterfs" target="_blank">mount.glusterfs</a>' +
+                        '<br />' +
+                      _('For 9PFS options, see man page for ') +
+                        '<a href="https://www.kernel.org/doc/Documentation/filesystems/9p.txt" target="_blank">mount.9pfs</a>'
+           }]
         }];
     },
 
@@ -183,6 +196,8 @@ Ext.define('OMV.module.admin.storage.remotemount.Mount', {
             options.setValue('rsize=8192,wsize=8192,timeo=14,intr,nofail');
         } else if (newValue === 'fuse.glusterfs') {
             options.setValue('_netdev,acl');
+        } else if (newValue === '9p') {
+            options.setValue('trans=virtio,version=9p2000.L,nobootwait,rw,_netdev');
         }
     }
 });

--- a/var/www/openmediavault/js/omv/module/admin/storage/remotemount/Mounts.js
+++ b/var/www/openmediavault/js/omv/module/admin/storage/remotemount/Mounts.js
@@ -60,6 +60,9 @@ Ext.define('OMV.module.admin.storage.remotemount.Mounts', {
                 case 'fuse.glusterfs':
                     content = _("GLUSTERFS");
                     break;
+                case '9p':
+                    content = _("9PFS");
+                    break;
             }
             return content;
         }


### PR DESCRIPTION
add 9pfs support

virtio filesahre between host <-> guest (KVM)
https://www.linux-kvm.org/page/9p_virtio
https://wiki.qemu.org/Documentation/9psetup
https://www.kernel.org/doc/Documentation/filesystems/9p.txt

I only test virtio transport mode(unix, tcp, fd, virtio, fd..)
![image](https://user-images.githubusercontent.com/10526492/55973264-21ad6a00-5cc0-11e9-96cd-4a9bff1851e5.png)
![image](https://user-images.githubusercontent.com/10526492/55973291-32f67680-5cc0-11e9-855b-d0888b10f9a0.png)
![image](https://user-images.githubusercontent.com/10526492/55973315-4275bf80-5cc0-11e9-8d15-a40c265b6f34.png)
